### PR TITLE
GPT API S3 연동 및 이미지 처리 최적화 (#24)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	implementation 'software.amazon.awssdk:s3'
+	implementation platform('software.amazon.awssdk:bom:2.25.19')
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/com/likelion/ai_teacher_a/domain/image/controller/ImageController.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/image/controller/ImageController.java
@@ -3,6 +3,8 @@ package com.likelion.ai_teacher_a.domain.image.controller;
 import com.likelion.ai_teacher_a.domain.image.dto.ImageResponseDto;
 import com.likelion.ai_teacher_a.domain.image.entity.ImageType;
 import com.likelion.ai_teacher_a.domain.image.service.ImageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -12,30 +14,29 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.Map;
 
+@Tag(name = "이미지 업로드", description = "이미지를 S3에 업로드하고 URL을 조회하는 API")
 @RestController
-@RequestMapping("/api/images")
+@RequestMapping("/api/public/images")
 @RequiredArgsConstructor
 public class ImageController {
 
     private final ImageService imageService;
 
+
+    @Operation(summary = "이미지를 S3에 업로드", description = "MultipartFile 형태로 이미지를 업로드하고 S3 URL과 정보를 반환합니다.")
     @PostMapping("/upload")
-    public ResponseEntity<ImageResponseDto> uploadImage(
-            @RequestParam("file") MultipartFile file
-    ) throws IOException {
-        return ResponseEntity.ok(
-                imageService.upload(file, ImageType.PROFILE)
-        );
+    public ResponseEntity<ImageResponseDto> uploadToS3(@RequestParam("file") MultipartFile file) throws IOException {
+        ImageResponseDto dto = imageService.uploadToS3AndSave(file, ImageType.ETC);
+        return ResponseEntity.ok(dto);
     }
 
+    @Operation(summary = "이미지 URL 조회", description = "이미지 ID를 이용해 S3에 저장된 이미지의 URL을 반환합니다.")
     @GetMapping("/{imageId}")
-    public ResponseEntity<byte[]> getImage(@PathVariable Long imageId) {
-        byte[] image = imageService.getImageData(imageId);
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.IMAGE_JPEG); // 또는 PNG로 처리 가능
-        return new ResponseEntity<>(image, headers, HttpStatus.OK);
+    public ResponseEntity<Map<String, Object>> getImageUrl(@PathVariable("imageId") Long imageId) {
+        String url = imageService.getImageUrl(imageId);
+        return ResponseEntity.ok(Map.of("imageId", imageId, "url", url));
     }
 }
 

--- a/src/main/java/com/likelion/ai_teacher_a/domain/image/dto/ImageResponseDto.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/image/dto/ImageResponseDto.java
@@ -13,6 +13,7 @@ public class ImageResponseDto {
     private Long imageId;
     private String fileName;
     private Integer fileSize;
+    private String url;
     private LocalDateTime uploadedAt;
-}
 
+}

--- a/src/main/java/com/likelion/ai_teacher_a/domain/image/entity/Image.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/image/entity/Image.java
@@ -24,15 +24,11 @@ public class Image {
 
     private LocalDateTime uploadedAt;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "image_id")
-    private Image profileImage;
-
     @Enumerated(EnumType.STRING)
     private ImageType type; // PROFILE, ETC
 
-    @Lob
-    private byte[] data;
+
+    private String url;
 
     @PrePersist
     public void onCreate() {

--- a/src/main/java/com/likelion/ai_teacher_a/domain/image/service/ImageService.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/image/service/ImageService.java
@@ -6,6 +6,7 @@ import com.likelion.ai_teacher_a.domain.image.entity.ImageType;
 import com.likelion.ai_teacher_a.domain.image.repository.ImageRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -16,26 +17,57 @@ public class ImageService {
 
     private final ImageRepository imageRepository;
 
-    public ImageResponseDto upload(MultipartFile file, ImageType type) throws IOException {
-        Image image = new Image();
-        image.setFileName(file.getOriginalFilename());
-        image.setFileSize((int) file.getSize());
-        image.setType(type);
-        image.setData(file.getBytes());
+    private final S3Uploader s3Uploader;
 
-        Image saved = imageRepository.save(image);
+
+    @Transactional
+    public ImageResponseDto uploadToS3AndSave(MultipartFile file, ImageType type) throws IOException {
+        // ✅ 1. S3 업로드
+        String url = s3Uploader.upload(file);
+
+        // ✅ 2. DB 저장
+        Image image = Image.builder()
+                .fileName(file.getOriginalFilename())
+                .fileSize((int) file.getSize())// 바이너리 저장 안 함
+                .type(type)
+                .url(url)
+                .build();
+
+        imageRepository.save(image);
+
+        // ✅ 3. DTO 반환
         return new ImageResponseDto(
-                saved.getImageId(),
-                saved.getFileName(),
-                saved.getFileSize(),
-                saved.getUploadedAt()
+                image.getImageId(),
+                image.getFileName(),
+                image.getFileSize(),
+                image.getUrl(),            // ✅ 4번째: url
+                image.getUploadedAt()      // ✅ 5번째: uploadedAt
         );
+
     }
 
-    public byte[] getImageData(Long imageId) {
+
+    @Transactional
+    public void deleteImage(Long imageId) {
         Image image = imageRepository.findById(imageId)
-                .orElseThrow(() -> new RuntimeException("Image not found"));
-        return image.getData();
-    }
-}
+                .orElseThrow(() -> new RuntimeException("이미지를 찾을 수 없습니다."));
 
+        // S3에서 삭제
+        if (image.getUrl() != null) {
+            s3Uploader.delete(image.getUrl());
+        }
+
+        // DB에서 삭제
+        imageRepository.delete(image);
+    }
+
+
+    @Transactional(readOnly = true)
+    public String getImageUrl(Long imageId) {
+        Image image = imageRepository.findById(imageId)
+                .orElseThrow(() -> new RuntimeException("이미지를 찾을 수 없습니다."));
+        return image.getUrl();
+    }
+
+
+}

--- a/src/main/java/com/likelion/ai_teacher_a/domain/image/service/S3Uploader.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/image/service/S3Uploader.java
@@ -1,0 +1,88 @@
+package com.likelion.ai_teacher_a.domain.image.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3Uploader {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+
+    public String upload(MultipartFile file) throws IOException {
+        String originalName = file.getOriginalFilename();
+        String rawFileName = UUID.randomUUID() + "_" + originalName;
+
+        getS3Client().putObject(
+                PutObjectRequest.builder()
+                        .bucket(bucket)
+                        .key(rawFileName)
+                        .acl("public-read")
+                        .contentType(file.getContentType())
+                        .build(),
+                software.amazon.awssdk.core.sync.RequestBody.fromBytes(file.getBytes())
+        );
+
+        return generatePublicUrl(rawFileName);
+    }
+
+
+    public void delete(String fileUrl) {
+        String key = extractKeyFromUrl(fileUrl);
+        System.out.println("🧹 Deleting S3 key: " + key); // 로그 확인용
+
+        getS3Client().deleteObject(builder ->
+                builder.bucket(bucket).key(key)
+        );
+    }
+
+
+    private S3Client getS3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(accessKey, secretKey)
+                        )
+                ).build();
+    }
+
+    private String generatePublicUrl(String rawFileName) {
+        String encodedFileName = URLEncoder.encode(rawFileName, StandardCharsets.UTF_8)
+                .replaceAll("\\+", "%20");
+        return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + encodedFileName;
+    }
+
+
+    private String extractKeyFromUrl(String fileUrl) {
+        String baseUrl = "https://" + bucket + ".s3." + region + ".amazonaws.com/";
+        String encodedKey = fileUrl.replace(baseUrl, "");
+        return URLDecoder.decode(encodedKey, StandardCharsets.UTF_8);
+    }
+
+
+}

--- a/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/controller/LogSolveController.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/controller/LogSolveController.java
@@ -1,5 +1,6 @@
 package com.likelion.ai_teacher_a.domain.logsolve.controller;
 
+import com.likelion.ai_teacher_a.domain.logsolve.dto.TotalLogCountDto;
 import com.likelion.ai_teacher_a.domain.logsolve.service.LogSolveService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -19,7 +20,7 @@ import java.util.Map;
 @Tag(name = "Math AI 문제해설", description = "AI 이미지 문제 해설 및 로그 관리 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/math")
+@RequestMapping("/api/public/math")
 public class LogSolveController {
 
     private final LogSolveService logSolveService;
@@ -71,6 +72,17 @@ public class LogSolveController {
             @Parameter(description = "사용자의 추가 질문") @RequestParam("question") String question
     ) {
         return logSolveService.executeFollowUp(logSolveId, question);
+    }
+
+
+    @Operation(
+            summary = "전체 문제해설 로그 수 조회",
+            description = "DB에 저장된 전체 LogSolve(문제해설 로그)의 총 개수를 반환합니다."
+    )
+    @GetMapping("/logs-total")
+    public ResponseEntity<TotalLogCountDto> getTotalLogCount() {
+        TotalLogCountDto total = logSolveService.getTotalLogCount();
+        return ResponseEntity.ok(total);
     }
 
 

--- a/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/dto/TotalLogCountDto.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/dto/TotalLogCountDto.java
@@ -1,0 +1,3 @@
+package com.likelion.ai_teacher_a.domain.logsolve.dto;
+
+public record TotalLogCountDto(long total) {}

--- a/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/service/LogSolveService.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/service/LogSolveService.java
@@ -6,8 +6,10 @@ import com.likelion.ai_teacher_a.domain.image.entity.Image;
 import com.likelion.ai_teacher_a.domain.image.entity.ImageType;
 import com.likelion.ai_teacher_a.domain.image.repository.ImageRepository;
 import com.likelion.ai_teacher_a.domain.image.service.ImageService;
+import com.likelion.ai_teacher_a.domain.image.service.S3Uploader;
 import com.likelion.ai_teacher_a.domain.logsolve.dto.LogSolveResponseDto;
 import com.likelion.ai_teacher_a.domain.logsolve.dto.PagedLogResponseDto;
+import com.likelion.ai_teacher_a.domain.logsolve.dto.TotalLogCountDto;
 import com.likelion.ai_teacher_a.domain.logsolve.entity.LogSolve;
 import com.likelion.ai_teacher_a.domain.logsolve.repository.LogSolveRepository;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +29,6 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -44,6 +45,7 @@ public class LogSolveService {
     private final LogSolveRepository logSolveRepository;
     private final ImageService imageService;
     private final ImageRepository imageRepository;
+    private final S3Uploader s3Uploader;
 
     private final ObjectMapper mapper = new ObjectMapper();
 
@@ -51,11 +53,10 @@ public class LogSolveService {
             .connectTimeout(Duration.ofSeconds(10))
             .build();
 
-
     public Map<String, Object> executeMath(Long logSolveId) {
         try {
             LogSolve logSolve = getLogSolveById(logSolveId);
-            String base64Image = encodeImageToBase64(logSolve.getImage().getImageId());
+            String imageUrl = logSolve.getImage().getUrl();
 
             String prompt = """
                     Read the following math problem image accurately using OCR, and according to the ‘Our Kid Math Explanation Helper’ app’s parent explanation guide, output only a pure JSON object conforming to the JSON schema below. The math explanation and instructional method should be at a 6th grade elementary school level, including very detailed explanations in 4–6 steps. Since real-time web search for visual aids is not possible, present visual aid suggestions as search keywords and example URLs (placeholders). Please respond only in Korean.
@@ -68,22 +69,25 @@ public class LogSolveService {
                       "core_concept": "Core concept of the problem (e.g., 'divisors and multiples')",
                       "parent_explanation": "Concise guide sentence that a parent can use to explain to their child",
                       "explanation_steps": [
-                        "Step 1: …",
-                        "Step 2: …",
-                        "Step 3: …",
-                        "Step 4: …",
-                        "Step 5: …"
-                      ],
-                      "visual_aid": [
                         {
-                          "title": "Example visual aid title",
-                          "search_term": "Example search keyword",
-                          "example_url": "https://placeholder.example.com/your-image.png"
+                          "title": "Step 1: Introduce the triangle angle rule",
+                          "description": "Explain that the sum of the internal angles of any triangle is always 180 degrees."
                         },
                         {
-                          "title": "Another visual aid title",
-                          "search_term": "Another search keyword",
-                          "example_url": "https://placeholder.example.com/another-image.png"
+                          "title": "Step 2: Identify the known angle",
+                          "description": "Point out that one of the angles is already given as 55 degrees."
+                        },
+                        {
+                          "title": "Step 3: Calculate the remaining angle sum",
+                          "description": "Subtract the known angle (55°) from 180° to find the sum of the other two angles."
+                        },
+                        {
+                          "title": "Step 4: Show the result of the subtraction",
+                          "description": "180° - 55° = 125°, which is the combined measure of angles ㉠ and ㉡."
+                        },
+                        {
+                          "title": "Step 5: Summarize the method",
+                          "description": "Remind the student that this approach works for any triangle when two angles are known."
                         }
                       ],
                       "example_questions": [
@@ -92,7 +96,7 @@ public class LogSolveService {
                       ]
                     }
                     ```""";
-            Map<String, Object> payload = buildPayload(prompt, base64Image, 8192);
+            Map<String, Object> payload = buildPayload(prompt, imageUrl, 8192);
 
             String gptContent = sendGptRequest(payload);
             Map<String, Object> result = parseGptJson(gptContent);
@@ -120,7 +124,7 @@ public class LogSolveService {
     }
 
     public Long createLogAndReturnId(MultipartFile imageFile) throws IOException {
-        ImageResponseDto imageDto = imageService.upload(imageFile, ImageType.ETC);
+        ImageResponseDto imageDto = imageService.uploadToS3AndSave(imageFile, ImageType.ETC);
         Image image = imageRepository.findById(imageDto.getImageId()).orElseThrow(() -> new RuntimeException("이미지 없음"));
 
         return logSolveRepository.save(LogSolve.builder().image(image).result("처리 중").build()).getLogSolveId();
@@ -133,6 +137,14 @@ public class LogSolveService {
         return new PagedLogResponseDto(logs, logsPage.getTotalElements(), logsPage.getTotalPages(), logsPage.getNumber());
     }
 
+
+    @Transactional(readOnly = true)
+    public TotalLogCountDto getTotalLogCount() {
+        long total = logSolveRepository.count();
+        return new TotalLogCountDto(total);
+    }
+
+
     @Transactional(readOnly = true)
     public Map<String, Object> getLogDetail(Long logSolveId) {
         LogSolve log = getLogSolveById(logSolveId);
@@ -144,22 +156,32 @@ public class LogSolveService {
         try {
             Map<String, Object> parsed = mapper.readValue(cleanJson(log.getResult()), Map.class);
             parsed.put("logSolveId", logSolveId);
+            parsed.put("image_url", log.getImage().getUrl());
             return parsed;
         } catch (Exception e) {
             throw new RuntimeException("상세 설명 JSON 파싱 실패: " + e.getMessage());
         }
     }
 
+    @Transactional
     public void deleteLogById(Long logSolveId) {
         LogSolve log = getLogSolveById(logSolveId);
-        logSolveRepository.delete(log);
+
+        // ✅ 1. S3에서 이미지 URL 추출 및 삭제
+        if (log.getImage() != null && log.getImage().getUrl() != null) {
+            s3Uploader.delete(log.getImage().getUrl());
+        }
+
+        // ✅ 2. DB에서 LogSolve + Image 삭제
+        logSolveRepository.delete(log); // cascade = REMOVE 덕분에 Image도 같이 삭제됨
     }
+
 
     public ResponseEntity<?> executeFollowUp(Long logSolveId, String followUpQuestion) {
         try {
             LogSolve logSolve = getLogSolveById(logSolveId);
             String prevJson = logSolve.getResult();
-            String base64Image = encodeImageToBase64(logSolve.getImage().getImageId());
+            String imageUrl = logSolve.getImage().getUrl();
 
             String prompt = String.format("""
                     You are an AI math explanation assistant for elementary school students.
@@ -190,7 +212,7 @@ public class LogSolveService {
                     }
                     ```            
                     """, followUpQuestion, prevJson);
-            Map<String, Object> payload = buildPayload(prompt, base64Image, 2048);
+            Map<String, Object> payload = buildPayload(prompt, imageUrl, 2048);
 
             String gptContent = sendGptRequest(payload);
             Map<String, Object> additional = parseGptJson(gptContent);
@@ -200,38 +222,31 @@ public class LogSolveService {
             logSolve.setResult(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(prevResult));
             logSolveRepository.save(logSolve);
 
-
             return ResponseEntity.ok(Map.of("message", "AI 추가 질문 풀이 완료", "logSolveId", logSolveId));
         } catch (Exception e) {
-
             return ResponseEntity.internalServerError().body(Map.of("message", "추가 질문 처리 실패", "error", e.getMessage()));
         }
     }
-
 
     private LogSolve getLogSolveById(Long id) {
         return logSolveRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 수학문제 해설이 없습니다."));
     }
 
-
-    private String encodeImageToBase64(Long imageId) throws IOException {
-        return Base64.getEncoder().encodeToString(imageService.getImageData(imageId));
-    }
-
-    private Map<String, Object> buildPayload(String prompt, String base64Image, int maxTokens) {
+    private Map<String, Object> buildPayload(String prompt, String imageUrl, int maxTokens) {
         return Map.of(
-                "model", "gpt-4o",
+                "model", "gpt-4.1-mini",
                 "messages", List.of(Map.of(
                         "role", "user",
                         "content", List.of(
                                 Map.of("type", "text", "text", prompt),
-                                Map.of("type", "image_url", "image_url", Map.of("url", "data:image/jpeg;base64," + base64Image))
+                                Map.of("type", "image_url", "image_url", Map.of("url", imageUrl)) // ✅ URL 직접 전달
                         )
                 )),
                 "max_tokens", maxTokens
         );
     }
+
 
     private String sendGptRequest(Map<String, Object> payload) throws IOException, InterruptedException {
         HttpRequest request = HttpRequest.newBuilder()
@@ -272,6 +287,7 @@ public class LogSolveService {
                             log.getImage().getImageId(),
                             log.getImage().getFileName(),
                             log.getImage().getFileSize(),
+                            log.getImage().getUrl(),
                             log.getImage().getUploadedAt()
                     ),
                     parsedResult,

--- a/src/main/java/com/likelion/ai_teacher_a/global/config/SecurityConfig.java
+++ b/src/main/java/com/likelion/ai_teacher_a/global/config/SecurityConfig.java
@@ -21,7 +21,7 @@ public class SecurityConfig {
         return http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/oauth/**", "/login/**").permitAll()
+                        .requestMatchers("/oauth/**", "/login/**","/api/public/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
## 💡 설명
- GPT Vision 요청 시 base64 대신 S3 이미지 URL을 전달하도록 구조 변경

## ✅ 변경 사항
- S3Uploader 추가 및 연동
- GptVisionService 내 `HttpRequest` 구조 변경
- 불필요한 base64 변환 제거

## 📌 관련 이슈
- Fixes #24

## 🧪 테스트
- Postman을 통해 `/api/public/math/*`모두 성공 확인
