### PR TITLE
fix: 로그 목록 정렬 기준을 image.uploadedAt으로 변경 (#30)

### DIFF
--- a/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/controller/LogSolveController.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/controller/LogSolveController.java
@@ -7,11 +7,17 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.security.PermitAll;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.data.domain.Pageable;
+
+
 
 import java.util.Map;
 
@@ -77,9 +83,15 @@ public class LogSolveController {
 
     @Operation(summary = "모든 문제해설 요약 목록 조회 (imageUrl + title, 전체)")
     @GetMapping("/all-logs")
-    public ResponseEntity<?> getAllSimpleLogs() {
-        return ResponseEntity.ok(logSolveService.getAllSimpleLogs());
+    public ResponseEntity<?> getSimpleLogs(
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "3") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "image.uploadedAt")); // ✅ 핵심!
+        return ResponseEntity.ok(logSolveService.getAllSimpleLogs(pageable));
     }
+
+
 
 
 }


### PR DESCRIPTION
### 변경 내용
- `/api/math/all-logs`의 페이징 정렬 기준을 `image.uploadedAt`으로 명시하여 오류 수정

### 관련 이슈
- close #30

### 테스트
- Postman으로 page=0,1,2 요청 시 정상 응답
- uploadedAt 기준 내림차순 확인 완료
