### PR TITLE
feat: 이미지 문제해설 요청 시 자녀 학년 grade를 @RequestParam으로 명시적 전달하도록 수정 (#38)

### DIFF
--- a/src/main/java/com/likelion/ai_teacher_a/domain/image/controller/ImageController.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/image/controller/ImageController.java
@@ -1,24 +1,21 @@
 package com.likelion.ai_teacher_a.domain.image.controller;
 
-import java.io.IOException;
-import java.util.Map;
-
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
-
 import com.likelion.ai_teacher_a.domain.image.dto.ImageResponseDto;
 import com.likelion.ai_teacher_a.domain.image.entity.ImageType;
 import com.likelion.ai_teacher_a.domain.image.service.ImageService;
-
+import com.likelion.ai_teacher_a.domain.user.entity.User;
+import com.likelion.ai_teacher_a.domain.user.repository.UserRepository;
+import com.likelion.ai_teacher_a.global.auth.resolver.annotation.LoginUserId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Map;
 
 @Tag(name = "이미지 업로드", description = "이미지를 S3에 업로드하고 URL을 조회하는 API")
 @RestController
@@ -26,20 +23,26 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ImageController {
 
-	private final ImageService imageService;
+    private final ImageService imageService;
+    private final UserRepository userRepository;
 
-	@Operation(summary = "이미지를 S3에 업로드", description = "MultipartFile 형태로 이미지를 업로드하고 S3 URL과 정보를 반환합니다.")
-	@PostMapping("/upload")
-	public ResponseEntity<ImageResponseDto> uploadToS3(@RequestParam("file") MultipartFile file) throws IOException {
-		ImageResponseDto dto = imageService.uploadToS3AndSave(file, ImageType.ETC);
-		return ResponseEntity.ok(dto);
-	}
+    @Operation(summary = "이미지를 S3에 업로드", description = "MultipartFile 형태로 이미지를 업로드하고 S3 URL과 정보를 반환합니다.")
+    @PostMapping("/upload")
+    public ResponseEntity<ImageResponseDto> uploadToS3(@RequestParam("file") MultipartFile file,
+                                                       @LoginUserId Long userId) throws IOException {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다"));
+        ImageResponseDto dto = imageService.uploadToS3AndSave(file, ImageType.ETC, user);
+        return ResponseEntity.ok(dto);
+    }
 
-	@Operation(summary = "이미지 URL 조회", description = "이미지 ID를 이용해 S3에 저장된 이미지의 URL을 반환합니다.")
-	@GetMapping("/{imageId}")
-	public ResponseEntity<Map<String, Object>> getImageUrl(@PathVariable("imageId") Long imageId) {
-		String url = imageService.getImageUrl(imageId);
-		return ResponseEntity.ok(Map.of("imageId", imageId, "url", url));
-	}
+    @Operation(summary = "이미지 URL 조회", description = "이미지 ID를 이용해 S3에 저장된 이미지의 URL을 반환합니다.")
+    @GetMapping("/{imageId}")
+    public ResponseEntity<Map<String, Object>> getImageUrl(@PathVariable("imageId") Long imageId, @LoginUserId Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다"));
+        String url = imageService.getImageUrl(imageId, user);
+        return ResponseEntity.ok(Map.of("imageId", imageId, "url", url));
+    }
 }
 

--- a/src/main/java/com/likelion/ai_teacher_a/domain/image/entity/Image.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/image/entity/Image.java
@@ -1,5 +1,6 @@
 package com.likelion.ai_teacher_a.domain.image.entity;
 
+import com.likelion.ai_teacher_a.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -27,6 +28,9 @@ public class Image {
     @Enumerated(EnumType.STRING)
     private ImageType type; // PROFILE, ETC
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
     private String url;
 

--- a/src/main/java/com/likelion/ai_teacher_a/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/image/repository/ImageRepository.java
@@ -1,8 +1,13 @@
 package com.likelion.ai_teacher_a.domain.image.repository;
 
 import com.likelion.ai_teacher_a.domain.image.entity.Image;
+import com.likelion.ai_teacher_a.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ImageRepository extends JpaRepository<Image, Long> {
+    Optional<Image> findByImageIdAndUser(Long imageId, User user);
+
 }
 

--- a/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/controller/LogSolveController.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/controller/LogSolveController.java
@@ -2,22 +2,22 @@ package com.likelion.ai_teacher_a.domain.logsolve.controller;
 
 import com.likelion.ai_teacher_a.domain.logsolve.dto.TotalLogCountDto;
 import com.likelion.ai_teacher_a.domain.logsolve.service.LogSolveService;
+import com.likelion.ai_teacher_a.domain.user.entity.User;
+import com.likelion.ai_teacher_a.domain.user.repository.UserRepository;
+import com.likelion.ai_teacher_a.global.auth.resolver.annotation.LoginUserId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.annotation.security.PermitAll;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.data.domain.Pageable;
-
-
 
 import java.util.Map;
 
@@ -28,19 +28,30 @@ import java.util.Map;
 public class LogSolveController {
 
     private final LogSolveService logSolveService;
+    private final UserRepository userRepository;
 
     @Operation(summary = "이미지 문제 업로드 및 AI 해설 시작")
     @PostMapping(value = "/solve", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<?> solveImage(@Parameter(description = "문제 이미지 파일") @RequestParam("mathProblemImage") MultipartFile image) {
-        return logSolveService.handleSolveImage(image);
+    public ResponseEntity<?> solveImage(
+            @Parameter(description = "문제 이미지 파일") @RequestParam("mathProblemImage") MultipartFile image,
+            @Parameter(description = "자녀 학년 (1~6)") @RequestParam("grade") int grade,
+            @LoginUserId Long userId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다"));
+
+        return logSolveService.handleSolveImage(image, user, grade);
     }
 
 
     @Operation(summary = "단일 문제해설 상세 조회")
     @GetMapping("/{logSolveId}")
-    public ResponseEntity<?> getLogDetail(@Parameter(description = "해당 문제해설 로그 ID") @PathVariable("logSolveId") Long logSolveId) {
+    public ResponseEntity<?> getLogDetail(@Parameter(description = "해당 문제해설 로그 ID") @PathVariable("logSolveId") Long logSolveId,
+                                          @LoginUserId Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다"));
         try {
-            Map<String, Object> result = logSolveService.getLogDetail(logSolveId);
+            Map<String, Object> result = logSolveService.getLogDetail(logSolveId, user);
             return ResponseEntity.ok(result);
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
@@ -50,10 +61,13 @@ public class LogSolveController {
 
     @Operation(summary = "문제해설 로그 삭제")
     @DeleteMapping("/{logSolveId}")
-    public ResponseEntity<?> deleteLog(@Parameter(description = "삭제할 로그 ID") @PathVariable("logSolveId") Long logSolveId) {
+    public ResponseEntity<?> deleteLog(@Parameter(description = "삭제할 로그 ID") @PathVariable("logSolveId") Long logSolveId,
+                                       @LoginUserId Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다"));
         try {
-            logSolveService.deleteLogById(logSolveId);
-            return ResponseEntity.ok().build();
+            logSolveService.deleteLogById(logSolveId, user);
+            return ResponseEntity.ok(Map.of("message", "삭제가 완료되었습니다."));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
                     .body(Map.of("message", e.getMessage()));
@@ -64,9 +78,12 @@ public class LogSolveController {
     @PostMapping("/ask-again/{logSolveId}")
     public ResponseEntity<?> askAgain(
             @Parameter(description = "기존 해설 로그 ID") @PathVariable("logSolveId") Long logSolveId,
-            @Parameter(description = "사용자의 추가 질문") @RequestParam("question") String question
+            @Parameter(description = "사용자의 추가 질문") @RequestParam("question") String question,
+            @LoginUserId Long userId
     ) {
-        return logSolveService.executeFollowUp(logSolveId, question);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다"));
+        return logSolveService.executeFollowUp(logSolveId, question, user);
     }
 
 
@@ -75,8 +92,10 @@ public class LogSolveController {
             description = "DB에 저장된 전체 LogSolve(문제해설 로그)의 총 개수를 반환합니다."
     )
     @GetMapping("/logs-total")
-    public ResponseEntity<TotalLogCountDto> getTotalLogCount() {
-        TotalLogCountDto total = logSolveService.getTotalLogCount();
+    public ResponseEntity<TotalLogCountDto> getTotalLogCount(@LoginUserId Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다"));
+        TotalLogCountDto total = logSolveService.getTotalLogCount(user);
         return ResponseEntity.ok(total);
     }
 
@@ -85,13 +104,15 @@ public class LogSolveController {
     @GetMapping("/all-logs")
     public ResponseEntity<?> getSimpleLogs(
             @RequestParam(name = "page", defaultValue = "0") int page,
-            @RequestParam(name = "size", defaultValue = "3") int size
+            @RequestParam(name = "size", defaultValue = "3") int size,
+            @LoginUserId Long userId
     ) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다"));
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "image.uploadedAt")); // ✅ 핵심!
-        return ResponseEntity.ok(logSolveService.getAllSimpleLogs(pageable));
+        return ResponseEntity.ok(logSolveService.getAllSimpleLogs(pageable, user));
     }
 
 
-
-
 }
+

--- a/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/entity/LogSolve.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/entity/LogSolve.java
@@ -1,6 +1,7 @@
 package com.likelion.ai_teacher_a.domain.logsolve.entity;
 
 import com.likelion.ai_teacher_a.domain.image.entity.Image;
+import com.likelion.ai_teacher_a.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -22,4 +23,9 @@ public class LogSolve {
 
     @Column(columnDefinition = "TEXT")
     private String result;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
 }

--- a/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/repository/LogSolveRepository.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/repository/LogSolveRepository.java
@@ -1,9 +1,16 @@
 package com.likelion.ai_teacher_a.domain.logsolve.repository;
 
 import com.likelion.ai_teacher_a.domain.logsolve.entity.LogSolve;
+import com.likelion.ai_teacher_a.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LogSolveRepository extends JpaRepository<LogSolve, Long> {
+    Page<LogSolve> findAllByUser(Pageable pageable, User user);
+
+    long countByUser(User user);
+
 }

--- a/src/main/java/com/likelion/ai_teacher_a/domain/userJr/dto/UserJrRequestDto.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/userJr/dto/UserJrRequestDto.java
@@ -11,7 +11,7 @@ public class UserJrRequestDto {
     private String name;
 
     @NotNull
-    private Integer schoolGrade;
+    private int schoolGrade;
 
     @NotNull
     private Long parentId;


### PR DESCRIPTION
### 🔧 변경사항
- `/api/math/solve` 요청 시 `User`의 자녀 정보를 참조하지 않고, 클라이언트에서 학년을 `@RequestParam("grade")`로 직접 전달하도록 수정
- 모든 메서드에 `@LoginUserId Long userId` 명시적으로 추가 완료
- `logSolveService.handleSolveImage(...)` 내부 로직도 인자로 받은 grade 기준으로 동작하도록 변경

### ✅ 테스트
- Postman에서 grade=3 등으로 요청 시 정상 응답 확인
- 유효하지 않은 학년 (예: grade=0 or 7) 입력 시 400 응답 처리 확인

### 📌 이슈
- closes #38
