### PR TITLE
feature40: delete user and add userjr's information modify

### DIFF
--- a/src/main/java/com/likelion/ai_teacher_a/domain/user/controller/UserController.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.likelion.ai_teacher_a.domain.user.controller;
 
+import org.springframework.security.core.Authentication;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -50,10 +51,17 @@ public class UserController {
 		return ResponseEntity.ok().build();
 	}
 
-	@Operation(summary = "사용자 삭제")
 	@DeleteMapping("/{id}")
 	public ResponseEntity<Void> delete(@PathVariable Long id) {
-		userService.deleteUser(id);
+		userService.deleteUserById(id);
 		return ResponseEntity.noContent().build();
 	}
+
+	@DeleteMapping("/me")
+	public ResponseEntity<Void> deleteCurrentUser(Authentication authentication) {
+		String email = authentication.getName();
+		userService.deleteUserByEmail(email);
+		return ResponseEntity.noContent().build();
+	}
+
 }

--- a/src/main/java/com/likelion/ai_teacher_a/domain/user/controller/UserController.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/user/controller/UserController.java
@@ -51,12 +51,14 @@ public class UserController {
 		return ResponseEntity.ok().build();
 	}
 
+	@Operation(summary = "사용자 삭제(관리자)")
 	@DeleteMapping("/{id}")
 	public ResponseEntity<Void> delete(@PathVariable Long id) {
 		userService.deleteUserById(id);
 		return ResponseEntity.noContent().build();
 	}
 
+	@Operation(summary = "사용자 탈퇴")
 	@DeleteMapping("/me")
 	public ResponseEntity<Void> deleteCurrentUser(Authentication authentication) {
 		String email = authentication.getName();

--- a/src/main/java/com/likelion/ai_teacher_a/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/user/repository/UserRepository.java
@@ -3,8 +3,8 @@ package com.likelion.ai_teacher_a.domain.user.repository;
 import com.likelion.ai_teacher_a.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
+import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    List<User> findAllByEmail(String email);
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/likelion/ai_teacher_a/domain/user/service/UserService.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/user/service/UserService.java
@@ -1,5 +1,8 @@
 package com.likelion.ai_teacher_a.domain.user.service;
 
+import com.likelion.ai_teacher_a.global.exception.CustomException;
+import com.likelion.ai_teacher_a.global.exception.ErrorCode;
+import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
 import com.likelion.ai_teacher_a.domain.image.entity.Image;
@@ -26,13 +29,13 @@ public class UserService {
 
 	public UserResponseDto getUser(Long id) {
 		User user = userRepository.findById(id)
-			.orElseThrow(() -> new RuntimeException("User not found"));
+				.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 		return UserResponseDto.from(user);
 	}
 
 	public UserResponseDto updateUser(Long id, UserRequestDto dto) {
 		User user = userRepository.findById(id)
-			.orElseThrow(() -> new RuntimeException("User not found"));
+				.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
 		user.setName(dto.getName());
 		user.setPhone(dto.getPhone());
@@ -40,20 +43,28 @@ public class UserService {
 		return UserResponseDto.from(userRepository.save(user));
 	}
 
-	public void deleteUser(Long id) {
-		userRepository.deleteById(id);
-	}
-
-	// 기존 createUser, getUser 등과 함께 위치
 	public void setProfileImage(Long userId, Long imageId) {
 		User user = userRepository.findById(userId)
-			.orElseThrow(() -> new RuntimeException("User not found"));
+				.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
 		Image image = imageRepository.findById(imageId)
-			.orElseThrow(() -> new RuntimeException("Image not found"));
+				.orElseThrow(() -> new CustomException(ErrorCode.IMAGE_NOT_FOUND)); // 이미지 관련 에러코드 추가 필요
 
 		user.setProfileImage(image);
 		userRepository.save(user);
+	}
+
+	public void deleteUserById(Long id) {
+		User user = userRepository.findById(id)
+				.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+		userRepository.delete(user);
+	}
+
+	public void deleteUserByEmail(String email) {
+		User user = userRepository.findByEmail(email)
+				.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+		userRepository.delete(user);
 	}
 }
 

--- a/src/main/java/com/likelion/ai_teacher_a/domain/userJr/controller/UserJrController.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/userJr/controller/UserJrController.java
@@ -2,6 +2,7 @@ package com.likelion.ai_teacher_a.domain.userJr.controller;
 
 import com.likelion.ai_teacher_a.domain.userJr.dto.UserJrRequestDto;
 import com.likelion.ai_teacher_a.domain.userJr.dto.UserJrResponseDto;
+import com.likelion.ai_teacher_a.domain.userJr.dto.UserJrUpdateRequestDto;
 import com.likelion.ai_teacher_a.domain.userJr.service.UserJrService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -52,6 +53,16 @@ public class UserJrController {
             @RequestParam Long imageId
     ) {
         userJrService.setProfileImage(userJrId, imageId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "자녀 정보 수정")
+    @PatchMapping("/{id}")
+    public ResponseEntity<Void> updateUserJr(
+            @PathVariable Long id,
+            @RequestBody UserJrUpdateRequestDto dto
+    ) {
+        userJrService.updateUserJr(id, dto);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/likelion/ai_teacher_a/domain/userJr/dto/UserJrUpdateRequestDto.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/userJr/dto/UserJrUpdateRequestDto.java
@@ -1,0 +1,21 @@
+package com.likelion.ai_teacher_a.domain.userJr.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserJrUpdateRequestDto {
+
+    private String name;
+
+    @Size(min = 1, max = 20, message = "닉네임은 1자 이상 20자 이하로 입력해주세요.")
+    private String nickname;
+
+    @Min(value = 1, message = "학년은 최소 1이어야 합니다.")
+    @Max(value = 9, message = "학년은 최대 9까지 가능합니다.")
+    private Integer schoolGrade;  // 예: 중1 = 7
+}

--- a/src/main/java/com/likelion/ai_teacher_a/domain/userJr/entity/UserJr.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/userJr/entity/UserJr.java
@@ -9,6 +9,7 @@ import lombok.*;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -19,6 +20,8 @@ public class UserJr {
     private Long id;
 
     private String name;
+
+    private String nickname;
 
     @Min(1) @Max(6)
     private int schoolGrade;
@@ -31,7 +34,4 @@ public class UserJr {
     @JoinColumn(name = "profile_image_id")
     private Image profileImage;
 
-    public void setProfileImage(Image image) {
-        this.profileImage = image;
-    }
 }

--- a/src/main/java/com/likelion/ai_teacher_a/domain/userJr/repository/UserJrRepository.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/userJr/repository/UserJrRepository.java
@@ -1,5 +1,6 @@
 package com.likelion.ai_teacher_a.domain.userJr.repository;
 
+import com.likelion.ai_teacher_a.domain.user.entity.User;
 import com.likelion.ai_teacher_a.domain.userJr.entity.UserJr;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,4 +11,7 @@ public interface UserJrRepository extends JpaRepository<UserJr, Long> {
 
     // ✅ 중복 체크 메서드 추가
     boolean existsByParentIdAndName(Long parentId, String name);
+
+    void deleteAllByUser(User user);
+
 }

--- a/src/main/java/com/likelion/ai_teacher_a/domain/userJr/service/UserJrService.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/userJr/service/UserJrService.java
@@ -6,8 +6,12 @@ import com.likelion.ai_teacher_a.domain.user.entity.User;
 import com.likelion.ai_teacher_a.domain.user.repository.UserRepository;
 import com.likelion.ai_teacher_a.domain.userJr.dto.UserJrRequestDto;
 import com.likelion.ai_teacher_a.domain.userJr.dto.UserJrResponseDto;
+import com.likelion.ai_teacher_a.domain.userJr.dto.UserJrUpdateRequestDto;
 import com.likelion.ai_teacher_a.domain.userJr.entity.UserJr;
 import com.likelion.ai_teacher_a.domain.userJr.repository.UserJrRepository;
+import com.likelion.ai_teacher_a.global.exception.CustomException;
+import com.likelion.ai_teacher_a.global.exception.ErrorCode;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -32,9 +36,9 @@ public class UserJrService {
             throw new RuntimeException("이미 같은 이름의 자녀가 등록되어 있습니다.");
         }
 
-        // ✅ 학년 범위 유효성 검사 (1~6: 초1~6)
+        // ✅ 학년 범위 유효성 검사 (1~9: 초1~중3)
         if (!isValidGrade(dto.getSchoolGrade())) {
-            throw new IllegalArgumentException("학년은 초등학교 1학년부터 6학년(1~6)까지만 가능합니다.");
+            throw new IllegalArgumentException("학년은 초등학교 1학년부터 중학교 3학년(1~9)까지만 가능합니다.");
         }
 
         UserJr userJr = UserJr.builder()
@@ -78,6 +82,26 @@ public class UserJrService {
     }
 
     private boolean isValidGrade(int grade) {
-        return grade >= 1 && grade <= 6;
+        return grade >= 1 && grade <= 9;
+    }
+
+    @Transactional
+    public void updateUserJr(Long userJrId, UserJrUpdateRequestDto dto) {
+        UserJr userJr = userJrRepository.findById(userJrId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_JR_NOT_FOUND));
+
+        if (dto.getName() != null) {
+            userJr.setName(dto.getName());
+        }
+
+        if (dto.getNickname() != null) {
+            userJr.setNickname(dto.getNickname());
+        }
+
+        if (dto.getSchoolGrade() != null) {
+            userJr.setSchoolGrade(dto.getSchoolGrade());
+        }
+
+        // 저장은 @Transactional 로 자동 flush 또는 명시적으로 save 가능
     }
 }

--- a/src/main/java/com/likelion/ai_teacher_a/global/config/CorsConfig.java
+++ b/src/main/java/com/likelion/ai_teacher_a/global/config/CorsConfig.java
@@ -18,7 +18,7 @@ public class CorsConfig {
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration config = new CorsConfiguration();
 		config.setAllowedOrigins(allowedOrigins);
-		config.setAllowedMethods(List.of("GET","POST","PUT","DELETE","OPTIONS"));
+		config.setAllowedMethods(List.of("GET","POST","PUT","DELETE","OPTIONS", "PATCH"));
 		config.setAllowedHeaders(List.of("*"));
 		config.setAllowCredentials(true);
 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/likelion/ai_teacher_a/global/exception/CustomException.java
+++ b/src/main/java/com/likelion/ai_teacher_a/global/exception/CustomException.java
@@ -1,0 +1,14 @@
+package com.likelion.ai_teacher_a.global.exception;
+
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/likelion/ai_teacher_a/global/exception/ErrorCode.java
+++ b/src/main/java/com/likelion/ai_teacher_a/global/exception/ErrorCode.java
@@ -1,0 +1,24 @@
+package com.likelion.ai_teacher_a.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+    USER_NOT_FOUND("사용자를 찾을 수 없습니다."),
+    INVALID_REQUEST("잘못된 요청입니다."),
+    UNAUTHORIZED("인증되지 않은 사용자입니다."),
+    FORBIDDEN("접근 권한이 없습니다."),
+    INTERNAL_SERVER_ERROR("서버 오류가 발생했습니다."),
+    IMAGE_NOT_FOUND("이미지를 찾을 수 없습니다."),
+    USER_JR_NOT_FOUND("자녀 정보를 찾을 수 없습니다.");
+
+
+    private final String message;
+
+    ErrorCode(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}


### PR DESCRIPTION
추가 작업 내용
회원 파트
- 회원 탈퇴 추가(기존에 사용자 삭제 부분 있었고, 그 삭제는 관리자에 의한 삭제라고 볼 수 있다. 회원 탈퇴는 회원에 의해서 탈퇴하는 로직을 추가했습니다) 

회원 자녀 파트
- 자녀의 이름 수정 추가
- 자녀의 학년 갱신 기능 추가(자동 갱신이 아닌 수동 갱신)