### PR TITLE
fix: GPT 응답에서 visual_aid_suggestions 제거 및 프롬프트 수정 (#42)

### DIFF
--- a/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/repository/LogSolveRepository.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/repository/LogSolveRepository.java
@@ -14,3 +14,4 @@ public interface LogSolveRepository extends JpaRepository<LogSolve, Long> {
     long countByUser(User user);
 
 }
+

--- a/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/service/LogSolveService.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/service/LogSolveService.java
@@ -80,7 +80,7 @@ public class LogSolveService {
 
     private String buildPromptByGrade(int grade) {
         return String.format("""
-                Read the following math problem image accurately using OCR, and according to the ‘Our Kid Math Explanation Helper’ app’s parent explanation guide, output only a pure JSON object conforming to the JSON schema below. The math explanation and instructional method should be at a 6th grade elementary school level, including very detailed explanations in 4–6 steps. Since real-time web search for visual aids is not possible, present visual aid suggestions as search keywords and example URLs (placeholders). Please respond only in Korean.
+                Read the following math problem image accurately using OCR, and according to the ‘Our Kid Math Explanation Helper’ app’s parent explanation guide, output only a pure JSON object conforming to the JSON schema below. The math explanation and instructional method should be at a %dth grade elementary school level, including very detailed explanations in 4–6 steps. Please respond only in Korean.
 
                 ```json
                 {

--- a/src/main/java/com/likelion/ai_teacher_a/domain/userJr/entity/UserJr.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/userJr/entity/UserJr.java
@@ -11,6 +11,7 @@ import lombok.*;
 @Getter
 @Setter
 @Builder
+@Table(name = "user_jr")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class UserJr {

--- a/src/main/java/com/likelion/ai_teacher_a/domain/userJr/repository/UserJrRepository.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/userJr/repository/UserJrRepository.java
@@ -12,6 +12,5 @@ public interface UserJrRepository extends JpaRepository<UserJr, Long> {
     // ✅ 중복 체크 메서드 추가
     boolean existsByParentIdAndName(Long parentId, String name);
 
-    void deleteAllByUser(User user);
 
 }


### PR DESCRIPTION
### 🔧 수정사항
- `LogSolveService.java` 내 `buildPromptByGrade()` 메서드에서 불필요한 문장 제거:
  > "Since real-time web search for visual aids is not possible, present visual aid suggestions as search keywords and example URLs (placeholders)."
- GPT가 `visual_aid_suggestions`를 포함하지 않도록 프롬프트 간소화

### ✅ 테스트 결과
- `/solve-image` 호출 시 더 이상 `visual_aid_suggestions` 포함되지 않음
- 프롬프트 기반 응답 정상 작동 확인


