### PR TITLE
feat: 자녀 삭제 시 연관된 로그 및 이미지 삭제 기능 추가 (#48)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.postgresql:postgresql'
 	implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter:1.0.0-M5'

--- a/src/main/java/com/likelion/ai_teacher_a/domain/image/dto/ImageAndResponseDto.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/image/dto/ImageAndResponseDto.java
@@ -1,0 +1,12 @@
+package com.likelion.ai_teacher_a.domain.image.dto;
+
+import com.likelion.ai_teacher_a.domain.image.entity.Image;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ImageAndResponseDto {
+    private Image image;                // 저장된 Image 엔티티
+    private ImageResponseDto response; // 클라이언트 응답용 DTO
+}

--- a/src/main/java/com/likelion/ai_teacher_a/domain/image/service/ImageService.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/image/service/ImageService.java
@@ -1,5 +1,6 @@
 package com.likelion.ai_teacher_a.domain.image.service;
 
+import com.likelion.ai_teacher_a.domain.image.dto.ImageAndResponseDto;
 import com.likelion.ai_teacher_a.domain.image.dto.ImageResponseDto;
 import com.likelion.ai_teacher_a.domain.image.entity.Image;
 import com.likelion.ai_teacher_a.domain.image.entity.ImageType;
@@ -68,6 +69,32 @@ public class ImageService {
         Image image = imageRepository.findByImageIdAndUser(imageId, user)
                 .orElseThrow(() -> new RuntimeException("이미지를 찾을 수 없습니다."));
         return image.getUrl();
+    }
+
+
+    @Transactional
+    public ImageAndResponseDto uploadToS3AndSaveWithEntity(MultipartFile file, ImageType type, User user) throws IOException {
+        String url = s3Uploader.upload(file);
+
+        Image image = Image.builder()
+                .fileName(file.getOriginalFilename())
+                .fileSize((int) file.getSize())
+                .type(type)
+                .url(url)
+                .user(user)
+                .build();
+
+        imageRepository.save(image);
+
+        ImageResponseDto response = new ImageResponseDto(
+                image.getImageId(),
+                image.getFileName(),
+                image.getFileSize(),
+                image.getUrl(),
+                image.getUploadedAt()
+        );
+
+        return new ImageAndResponseDto(image, response);
     }
 
 

--- a/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/entity/LogSolve.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/entity/LogSolve.java
@@ -2,8 +2,11 @@ package com.likelion.ai_teacher_a.domain.logsolve.entity;
 
 import com.likelion.ai_teacher_a.domain.image.entity.Image;
 import com.likelion.ai_teacher_a.domain.user.entity.User;
+import com.likelion.ai_teacher_a.domain.userJr.entity.UserJr;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Table(name = "log_solve")
@@ -17,9 +20,10 @@ public class LogSolve {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long logSolveId;
 
-    @OneToOne
+    @OneToOne(cascade = CascadeType.REMOVE, orphanRemoval = true)
     @JoinColumn(name = "image_id")
     private Image image;
+
 
     @Column(columnDefinition = "TEXT")
     private String result;
@@ -27,5 +31,11 @@ public class LogSolve {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_jr_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private UserJr userJr;
+
 
 }

--- a/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/repository/LogSolveRepository.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/repository/LogSolveRepository.java
@@ -2,16 +2,28 @@ package com.likelion.ai_teacher_a.domain.logsolve.repository;
 
 import com.likelion.ai_teacher_a.domain.logsolve.entity.LogSolve;
 import com.likelion.ai_teacher_a.domain.user.entity.User;
+import com.likelion.ai_teacher_a.domain.userJr.entity.UserJr;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface LogSolveRepository extends JpaRepository<LogSolve, Long> {
     Page<LogSolve> findAllByUser(Pageable pageable, User user);
 
     long countByUser(User user);
+
+
+    Page<LogSolve> findAllByUserJr(Pageable pageable, UserJr userJr);
+
+    @Query("SELECT l FROM LogSolve l WHERE l.userJr = :userJr")
+    List<LogSolve> findAllByUserJr(@Param("userJr") UserJr userJr);
+
 
 }
 

--- a/src/main/java/com/likelion/ai_teacher_a/domain/userJr/dto/UserJrRequestDto.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/userJr/dto/UserJrRequestDto.java
@@ -1,18 +1,17 @@
 package com.likelion.ai_teacher_a.domain.userJr.dto;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
 public class UserJrRequestDto {
 
-    @NotBlank
-    private String name;
+
+    @Size(min = 1, max = 20, message = "닉네임은 1자 이상 20자 이하로 입력해주세요.")
+    private String nickname;
 
     @NotNull
     private int schoolGrade;
 
-    @NotNull
-    private Long parentId;
 }

--- a/src/main/java/com/likelion/ai_teacher_a/domain/userJr/dto/UserJrResponseDto.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/userJr/dto/UserJrResponseDto.java
@@ -12,20 +12,22 @@ public class UserJrResponseDto {
     private String name;
     private int schoolGrade;
     private Long parentId;
-    private Long profileImageId;
+    private String profileImageUrl;
 
     public static UserJrResponseDto from(UserJr userJr) {
-        Long profileImageId = null;
-        if (userJr.getProfileImage() != null && userJr.getProfileImage().getImageId() != null) {
-            profileImageId = userJr.getProfileImage().getImageId();
+        String profileImageUrl = null;
+        if (userJr.getImage() != null && userJr.getImage().getUrl() != null) {
+            profileImageUrl = userJr.getImage().getUrl();
         }
 
         return UserJrResponseDto.builder()
-                .id(userJr.getId())
-                .name(userJr.getName())
+                .id(userJr.getUserJrId())
+                .name(userJr.getNickname())
                 .schoolGrade(userJr.getSchoolGrade())
-                .parentId(userJr.getParent().getId())
-                .profileImageId(profileImageId)
+                .parentId(userJr.getUser().getId())
+                .profileImageUrl(profileImageUrl)
                 .build();
     }
+
+
 }

--- a/src/main/java/com/likelion/ai_teacher_a/domain/userJr/dto/UserJrUpdateRequestDto.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/userJr/dto/UserJrUpdateRequestDto.java
@@ -10,7 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class UserJrUpdateRequestDto {
 
-    private String name;
 
     @Size(min = 1, max = 20, message = "닉네임은 1자 이상 20자 이하로 입력해주세요.")
     private String nickname;

--- a/src/main/java/com/likelion/ai_teacher_a/domain/userJr/entity/UserJr.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/userJr/entity/UserJr.java
@@ -18,21 +18,33 @@ public class UserJr {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Long userJrId;
 
-    private String name;
 
     private String nickname;
 
-    @Min(1) @Max(6)
+    @Min(1)
+    @Max(6)
     private int schoolGrade;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "parent_id")
-    private User parent;
+    @JoinColumn(name = "user_id")
+    private User user;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "profile_image_id")
-    private Image profileImage;
+
+    @OneToOne(orphanRemoval = true, cascade = CascadeType.ALL)
+    @JoinColumn(name = "image_id")
+    private Image image;
+
+
+
+    @Builder
+    public UserJr(String nickname, int schoolGrade, User user, Image image) {
+        this.nickname = nickname;
+        this.schoolGrade = schoolGrade;
+        this.user = user;
+        this.image = image;
+    }
+
 
 }

--- a/src/main/java/com/likelion/ai_teacher_a/domain/userJr/repository/UserJrRepository.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/userJr/repository/UserJrRepository.java
@@ -3,14 +3,19 @@ package com.likelion.ai_teacher_a.domain.userJr.repository;
 import com.likelion.ai_teacher_a.domain.user.entity.User;
 import com.likelion.ai_teacher_a.domain.userJr.entity.UserJr;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface UserJrRepository extends JpaRepository<UserJr, Long> {
-    List<UserJr> findByParentId(Long parentId);
 
-    // ✅ 중복 체크 메서드 추가
-    boolean existsByParentIdAndName(Long parentId, String name);
+    @Query("SELECT uj FROM UserJr uj JOIN FETCH uj.user WHERE uj.user.id = :userId")
+    List<UserJr> findByUserIdFetchJoin(@Param("userId") Long userId);
 
-    void deleteAllByParent(User user);
+
+    boolean existsByUserIdAndNickname(Long userId, String nickname);
+
+
+    void deleteAllByUser(User user);
 }

--- a/src/main/java/com/likelion/ai_teacher_a/global/auth/util/JwtUtil.java
+++ b/src/main/java/com/likelion/ai_teacher_a/global/auth/util/JwtUtil.java
@@ -14,7 +14,7 @@ import io.jsonwebtoken.security.Keys;
 @Component
 public class JwtUtil {
 	private final Key key;
-	private final long ACCESS_TOKEN_EXPIRATION_TIME = 1000 * 60 * 60; // 1시간
+	private final long ACCESS_TOKEN_EXPIRATION_TIME = 1000 * 60 * 60*24; // 1시간
 	private final long REFRESH_TOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 7; // 7일
 
 	public JwtUtil() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,7 +34,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQL8Dialect
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
## ✨ 주요 변경사항
- UserJr CRUD 전체수정 및 삭제 시 관련 LogSolve 및 Image 레코드 자동 삭제 처리
- LogSolve의 image 필드에 CascadeType.REMOVE 및 orphanRemoval=true 설정
- S3Uploader를 통해 업로드된 이미지도 삭제되도록 처리

## 🧪 테스트
- 자녀 삭제 시 로그 및 이미지 DB 레코드 제거 확인
- 이미지 S3에서도 정상적으로 삭제됨

## 🔗 관련 이슈
- Closes #52
