### PR TITLE
Fix/#61 userjr nplus1

### DIFF
--- a/src/main/java/com/likelion/ai_teacher_a/domain/userJr/repository/UserJrRepository.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/userJr/repository/UserJrRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface UserJrRepository extends JpaRepository<UserJr, Long> {
 
@@ -21,4 +22,13 @@ public interface UserJrRepository extends JpaRepository<UserJr, Long> {
     boolean existsByUserIdAndNickname(Long userId, String nickname);
 
     void deleteAllByUser(User user);
+
+    @Query("""
+                SELECT uj FROM UserJr uj
+                LEFT JOIN FETCH uj.user
+                LEFT JOIN FETCH uj.image
+                WHERE uj.userJrId = :userJrId
+            """)
+    Optional<UserJr> findByIdWithUserAndImage(@Param("userJrId") Long userJrId);
+
 }

--- a/src/main/java/com/likelion/ai_teacher_a/domain/userJr/service/UserJrService.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/userJr/service/UserJrService.java
@@ -82,9 +82,10 @@ public class UserJrService {
     }
 
     public UserJrResponseDto findById(Long userJrId, Long userId) {
-        UserJr userJr = userJrRepository.findById(userJrId)
+        UserJr userJr = userJrRepository.findByIdWithUserAndImage(userJrId)
                 .filter(jr -> jr.getUser().getId().equals(userId))
                 .orElseThrow(() -> new RuntimeException("자녀 정보를 찾을 수 없거나 권한이 없습니다."));
+
         return UserJrResponseDto.from(userJr);
     }
 
@@ -115,7 +116,6 @@ public class UserJrService {
 
         userJrRepository.delete(userJr);
     }
-
 
 
     private boolean isValidGrade(int grade) {


### PR DESCRIPTION
## 🔧 작업 내용

- UserJr 단건 조회 시 `User`, `Image` 지연 로딩으로 인한 N+1 문제 발생
- Fetch Join 적용된 `findByIdWithUserAndImage()` 쿼리 작성
- 서비스 로직에서 기존 `findById()` → `findByIdWithUserAndImage()`로 교체하여 쿼리 1회로 조회 완료
- JPA 로그 기반 쿼리 실행 확인 (쿼리 1회로 해결)

---

## 📸 확인 결과 (Hibernate 로그)

- 실행 쿼리:
```sql
SELECT uj FROM UserJr uj
LEFT JOIN FETCH uj.user
LEFT JOIN FETCH uj.image
WHERE uj.userJrId = ?
