### PR TITLE
fix: 자녀 삭제 시 불필요한 update 제거 (#63)

### DIFF
--- a/src/main/java/com/likelion/ai_teacher_a/domain/image/controller/ImageController.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/image/controller/ImageController.java
@@ -30,18 +30,16 @@ public class ImageController {
     @PostMapping("/upload")
     public ResponseEntity<ImageResponseDto> uploadToS3(@RequestParam("file") MultipartFile file,
                                                        @LoginUserId Long userId) throws IOException {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다"));
-        ImageResponseDto dto = imageService.uploadToS3AndSave(file, ImageType.ETC, user);
+
+        ImageResponseDto dto = imageService.uploadToS3AndSave(file, ImageType.ETC, userId);
         return ResponseEntity.ok(dto);
     }
 
     @Operation(summary = "이미지 URL 조회", description = "이미지 ID를 이용해 S3에 저장된 이미지의 URL을 반환합니다.")
     @GetMapping("/{imageId}")
     public ResponseEntity<Map<String, Object>> getImageUrl(@PathVariable("imageId") Long imageId, @LoginUserId Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다"));
-        String url = imageService.getImageUrl(imageId, user);
+
+        String url = imageService.getImageUrl(imageId, userId);
         return ResponseEntity.ok(Map.of("imageId", imageId, "url", url));
     }
 }

--- a/src/main/java/com/likelion/ai_teacher_a/domain/image/service/ImageService.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/image/service/ImageService.java
@@ -6,6 +6,7 @@ import com.likelion.ai_teacher_a.domain.image.entity.Image;
 import com.likelion.ai_teacher_a.domain.image.entity.ImageType;
 import com.likelion.ai_teacher_a.domain.image.repository.ImageRepository;
 import com.likelion.ai_teacher_a.domain.user.entity.User;
+import com.likelion.ai_teacher_a.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,10 +21,12 @@ public class ImageService {
     private final ImageRepository imageRepository;
 
     private final S3Uploader s3Uploader;
+    private final UserRepository userRepository;
 
 
     @Transactional
-    public ImageResponseDto uploadToS3AndSave(MultipartFile file, ImageType type, User user) throws IOException {
+    public ImageResponseDto uploadToS3AndSave(MultipartFile file, ImageType type, Long userId) throws IOException {
+        User user = userRepository.getReferenceById(userId);
 
         String url = s3Uploader.upload(file);
 
@@ -51,11 +54,12 @@ public class ImageService {
 
 
     @Transactional
-    public void deleteImage(Long imageId, User user) {
+    public void deleteImage(Long imageId, Long userId) {
+        User user = userRepository.getReferenceById(userId);
         Image image = imageRepository.findById(imageId)
                 .orElseThrow(() -> new RuntimeException("이미지를 찾을 수 없습니다."));
 
-        // S3에서 삭제
+
         if (image.getUrl() != null) {
             s3Uploader.delete(image.getUrl());
         }
@@ -65,7 +69,8 @@ public class ImageService {
 
 
     @Transactional(readOnly = true)
-    public String getImageUrl(Long imageId, User user) {
+    public String getImageUrl(Long imageId, Long userId) {
+        User user = userRepository.getReferenceById(userId);
         Image image = imageRepository.findByImageIdAndUser(imageId, user)
                 .orElseThrow(() -> new RuntimeException("이미지를 찾을 수 없습니다."));
         return image.getUrl();
@@ -73,7 +78,8 @@ public class ImageService {
 
 
     @Transactional
-    public ImageAndResponseDto uploadToS3AndSaveWithEntity(MultipartFile file, ImageType type, User user) throws IOException {
+    public ImageAndResponseDto uploadToS3AndSaveWithEntity(MultipartFile file, ImageType type, Long userId) throws IOException {
+        User user = userRepository.getReferenceById(userId);
         String url = s3Uploader.upload(file);
 
         Image image = Image.builder()

--- a/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/entity/LogSolve.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/entity/LogSolve.java
@@ -7,9 +7,14 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "log_solve")
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -24,6 +29,9 @@ public class LogSolve {
     @JoinColumn(name = "image_id")
     private Image image;
 
+    @Column(length = 500)
+    private String problemTitle;
+
 
     @Column(columnDefinition = "TEXT")
     private String result;
@@ -36,6 +44,10 @@ public class LogSolve {
     @JoinColumn(name = "user_jr_id")
     @OnDelete(action = OnDeleteAction.CASCADE)
     private UserJr userJr;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
 
 
 }

--- a/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/repository/LogSolveRepository.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/repository/LogSolveRepository.java
@@ -5,6 +5,7 @@ import com.likelion.ai_teacher_a.domain.user.entity.User;
 import com.likelion.ai_teacher_a.domain.userJr.entity.UserJr;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -43,6 +44,10 @@ public interface LogSolveRepository extends JpaRepository<LogSolve, Long> {
                 WHERE l.id = :logSolveId
             """)
     Optional<LogSolve> findByIdWithImageAndUser(@Param("logSolveId") Long logSolveId);
+
+
+    @EntityGraph(attributePaths = {"image"})
+    Page<LogSolve> findAllByUserJr(UserJr userJr, Pageable pageable);
 
 
 }

--- a/src/main/java/com/likelion/ai_teacher_a/domain/userJr/controller/UserJrController.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/userJr/controller/UserJrController.java
@@ -14,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 @Tag(name = "User-Jr", description = "사용자 자녀 관련 API")
@@ -57,14 +58,15 @@ public class UserJrController {
     }
 
 
-    @Operation(summary = "자녀 정보 수정 (이미지 제외)")
+    @Operation(summary = "자녀 정보 수정 (이미지 포함 가능)")
     @PatchMapping(value = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Void> updateUserJr(
             @LoginUserId Long userId,
             @PathVariable Long id,
-            @RequestPart("metadata") @Valid UserJrUpdateRequestDto dto
-    ) {
-        userJrService.updateUserJr(id, dto, userId);
+            @RequestPart("metadata") @Valid UserJrUpdateRequestDto dto,
+            @RequestPart(value = "image", required = false) MultipartFile imageFile
+    ) throws IOException {
+        userJrService.updateUserJr(id, dto, userId, imageFile); // ⬅️ 이미지도 넘김
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/likelion/ai_teacher_a/domain/userJr/repository/UserJrRepository.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/userJr/repository/UserJrRepository.java
@@ -1,32 +1,39 @@
 package com.likelion.ai_teacher_a.domain.userJr.repository;
 
-import java.util.List;
-import java.util.Optional;
-
+import com.likelion.ai_teacher_a.domain.userJr.entity.UserJr;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import com.likelion.ai_teacher_a.domain.userJr.entity.UserJr;
+import java.util.List;
+import java.util.Optional;
 
 public interface UserJrRepository extends JpaRepository<UserJr, Long> {
 
-	@Query("""
-		SELECT uj FROM UserJr uj
-		LEFT JOIN FETCH uj.user
-		LEFT JOIN FETCH uj.image
-		WHERE uj.user.id = :userId
-		ORDER BY uj.userJrId ASC""")
-	List<UserJr> findByUserIdFetchJoin(@Param("userId") Long userId);
+    @Query("""
+            SELECT uj FROM UserJr uj
+            LEFT JOIN FETCH uj.user
+            LEFT JOIN FETCH uj.image
+            WHERE uj.user.id = :userId
+            ORDER BY uj.userJrId ASC""")
+    List<UserJr> findByUserIdFetchJoin(@Param("userId") Long userId);
 
-	boolean existsByUserIdAndNickname(Long userId, String nickname);
+    boolean existsByUserIdAndNickname(Long userId, String nickname);
 
-	@Query("""
-		    SELECT uj FROM UserJr uj
-		    LEFT JOIN FETCH uj.user
-		    LEFT JOIN FETCH uj.image
-		    WHERE uj.userJrId = :userJrId
-		""")
-	Optional<UserJr> findByIdWithUserAndImage(@Param("userJrId") Long userJrId);
+    @Query("""
+                SELECT uj FROM UserJr uj
+                LEFT JOIN FETCH uj.user
+                LEFT JOIN FETCH uj.image
+                WHERE uj.userJrId = :userJrId
+            """)
+    Optional<UserJr> findByIdWithUserAndImage(@Param("userJrId") Long userJrId);
+
+    @Query("""
+                SELECT uj FROM UserJr uj
+                JOIN FETCH uj.user
+                WHERE uj.id = :id
+            """)
+    Optional<UserJr> findByIdWithUser(@Param("id") Long id);
+
 
 }


### PR DESCRIPTION
이미지 수정및 자녀삭제 
### 기대 동작
- `DELETE`만 수행되고, `UPDATE`는 발생하지 않도록 JPA 연관 관계 및 서비스 로직 개선
- orphanRemoval, Cascade 설정 점검
- `userJr.image`, `log.image` 관련 직접 삭제 여부 확인

### 작업 항목
- [x] `UserJrService.delete()` 내 update 제거
- [x] JPA 관계 수정으로 자연스러운 삭제 흐름 유도
- [x] 필요 시 로그 남기기