### PR TITLE
fix: 자녀 삭제 시 이미지 및 로그 병렬 삭제 성능 개선(#65)

### DIFF
--- a/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/service/LogSolveService.java
+++ b/src/main/java/com/likelion/ai_teacher_a/domain/logsolve/service/LogSolveService.java
@@ -152,6 +152,12 @@ public class LogSolveService {
             Map<String, Object> result = executeMath(logSolve.getLogSolveId(), grade);
 
             String resultJson = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(result);
+
+            if (resultJson == null || resultJson.isBlank()) {
+                throw new RuntimeException("AI 응답에 문제가 있어 저장하지 않습니다.");
+            }
+
+
             logSolve.setResult(resultJson);
             logSolveRepository.save(logSolve);
 


### PR DESCRIPTION
## 🔧 변경사항
- `UserJrService.delete()` 내부 로직 리팩토링
- 자녀 삭제 시 관련 `LogSolve` → `Image` S3 URL 병렬 삭제 (`parallelStream`)
- 프로필 이미지 S3 + DB 삭제 처리 추가
- `userJrRepository.delete()` 전 불필요한 cascade 제거로 삭제 안정성 확보

## 📌 관련 이슈
- Closes #65

## ✅ 검토 포인트
- 병렬 삭제로 인한 `S3Uploader`의 thread-safe 여부 확인
- 추후 `LogSolve`와 `Image` 간의 연관관계 cascade 전략 점검 필요
